### PR TITLE
Feature implementation from commits f905a8d..6c0cc48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v486</artifactId>
-      <version>cbc6436</version>
+      <artifactId>bedrock-v503</artifactId>
+      <version>f32c76d</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v475</artifactId>
-      <version>c22aa595</version>
+      <artifactId>bedrock-v486</artifactId>
+      <version>cbc6436</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v440</artifactId>
-      <version>1656151</version>
+      <artifactId>bedrock-v448</artifactId>
+      <version>ddfa38b</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>e316986</version>
+      <version>6e318f5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,13 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>f7f84e7</version>
+      <version>6e318f5</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.GeyserMC</groupId>
+      <artifactId>PacketLib</artifactId>
+      <version>6e5dea9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v503</artifactId>
-      <version>f32c76d</version>
+      <artifactId>bedrock-v527</artifactId>
+      <version>977a9a1</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
       <artifactId>bedrock-v475</artifactId>
       <version>c22aa595</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.nukkitx.fastutil</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v448</artifactId>
-      <version>ddfa38b</version>
+      <artifactId>bedrock-v465</artifactId>
+      <version>fa9d104</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.16</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>6e318f5</version>
+      <version>bcd83c6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>PacketLib</artifactId>
-      <version>6e5dea9</version>
+      <version>9e38c61</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>bcd83c6</version>
+      <version>15df12a</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>PacketLib</artifactId>
-      <version>9e38c61</version>
+      <version>7ff2c93</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v471</artifactId>
-      <version>b71f1c9</version>
+      <artifactId>bedrock-v475</artifactId>
+      <version>c22aa595</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -29,13 +29,7 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>6e318f5</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.GeyserMC</groupId>
-      <artifactId>PacketLib</artifactId>
-      <version>6e5dea9</version>
+      <version>f7f84e7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.github.GeyserMC</groupId>
       <artifactId>MCProtocolLib</artifactId>
-      <version>15df12a</version>
+      <version>7efa636</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v465</artifactId>
-      <version>fa9d104</version>
+      <artifactId>bedrock-v471</artifactId>
+      <version>b71f1c9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockPlayer.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockPlayer.java
@@ -29,6 +29,7 @@ import com.google.gson.JsonObject;
 import com.nukkitx.math.vector.Vector2f;
 import com.nukkitx.math.vector.Vector3f;
 import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.nbt.NbtMap;
 import com.nukkitx.protocol.bedrock.BedrockServerSession;
 import com.nukkitx.protocol.bedrock.data.*;
 import com.nukkitx.protocol.bedrock.packet.*;
@@ -84,6 +85,7 @@ public class BedrockPlayer implements Player {
         startGamePacket.setPlayerGameType(GameType.CREATIVE);
         startGamePacket.setPlayerPosition(Vector3f.from(0, 64 + 2, 0));
         startGamePacket.setRotation(Vector2f.ONE);
+        startGamePacket.setPlayerPropertyData(NbtMap.EMPTY);
 
         startGamePacket.setSeed(-1);
         startGamePacket.setDimensionId(2);
@@ -120,6 +122,7 @@ public class BedrockPlayer implements Player {
         startGamePacket.setLevelId("");
         startGamePacket.setLevelName("GlobalLinkServer");
         startGamePacket.setPremiumWorldTemplateId("");
+        startGamePacket.setWorldTemplateId(new UUID(0, 0));
         startGamePacket.setCurrentTick(0);
         startGamePacket.setEnchantmentSeed(0);
         startGamePacket.setMultiplayerCorrelationId("");

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockServer.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockServer.java
@@ -29,9 +29,9 @@ import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
 import com.nukkitx.protocol.bedrock.BedrockPong;
 import com.nukkitx.protocol.bedrock.BedrockServerEventHandler;
 import com.nukkitx.protocol.bedrock.BedrockServerSession;
-import com.nukkitx.protocol.bedrock.v428.Bedrock_v428;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.globallinkserver.Server;
+import org.geysermc.globallinkserver.bedrock.util.BedrockVersionUtils;
 import org.geysermc.globallinkserver.config.Config;
 import org.geysermc.globallinkserver.link.LinkManager;
 import org.geysermc.globallinkserver.player.PlayerManager;
@@ -65,7 +65,7 @@ public class BedrockServer implements Server {
         pong.setGameType("Survival");
         pong.setIpv4Port(config.getBedrockPort());
 
-        BedrockPacketCodec codec = Bedrock_v428.V428_CODEC;
+        BedrockPacketCodec codec = BedrockVersionUtils.LATEST_CODEC;
         pong.setProtocolVersion(codec.getProtocolVersion());
         pong.setVersion(codec.getMinecraftVersion());
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
@@ -82,8 +82,10 @@ public class PacketHandler implements BedrockPacketHandler {
         session.setPacketCodec(packetCodec);
 
         try {
-            JsonObject extraData = Utils.validateData(packet.getChainData().toString(),
-                    packet.getSkinData().toString());
+            JsonObject extraData = Utils.validateData(
+                    packet.getChainData().toString(),
+                    packet.getSkinData().toString()
+            );
 
             player = playerManager.addBedrockPlayer(session, extraData);
 
@@ -93,7 +95,7 @@ public class PacketHandler implements BedrockPacketHandler {
 
             ResourcePacksInfoPacket info = new ResourcePacksInfoPacket();
             session.sendPacket(info);
-        } catch (AssertionError | IllegalStateException error) {
+        } catch (AssertionError | Exception error) {
             session.disconnect("disconnect.loginFailed");
         }
         return true;

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
@@ -69,7 +69,7 @@ public class PacketHandler implements BedrockPacketHandler {
 
         if (packetCodec == null) {
             PlayStatusPacket status = new PlayStatusPacket();
-            if (packet.getProtocolVersion() > packet.getProtocolVersion()) {
+            if (packet.getProtocolVersion() > BedrockVersionUtils.getLatestProtocolVersion()) {
                 status.setStatus(PlayStatusPacket.Status.LOGIN_FAILED_SERVER_OLD);
             } else {
                 status.setStatus(PlayStatusPacket.Status.LOGIN_FAILED_CLIENT_OLD);

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -36,6 +36,7 @@ import com.nukkitx.protocol.bedrock.v465.Bedrock_v465;
 import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
 import com.nukkitx.protocol.bedrock.v475.Bedrock_v475;
 import com.nukkitx.protocol.bedrock.v486.Bedrock_v486;
+import com.nukkitx.protocol.bedrock.v503.Bedrock_v503;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +49,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v486.V486_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v503.V503_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -64,6 +65,7 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.V465_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.V471_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v475.V475_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v486.V486_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -37,6 +37,7 @@ import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
 import com.nukkitx.protocol.bedrock.v475.Bedrock_v475;
 import com.nukkitx.protocol.bedrock.v486.Bedrock_v486;
 import com.nukkitx.protocol.bedrock.v503.Bedrock_v503;
+import com.nukkitx.protocol.bedrock.v527.Bedrock_v527;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +50,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v503.V503_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v527.V527_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -66,6 +67,7 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.V471_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v475.V475_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v486.V486_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v503.V503_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -32,7 +32,8 @@ import com.nukkitx.protocol.bedrock.v428.Bedrock_v428;
 import com.nukkitx.protocol.bedrock.v431.Bedrock_v431;
 import com.nukkitx.protocol.bedrock.v440.Bedrock_v440;
 import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
-import com.nukkitx.protocol.bedrock.v448.Bedrock_v465;
+import com.nukkitx.protocol.bedrock.v465.Bedrock_v465;
+import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v465.V465_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v471.V471_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -62,7 +63,8 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.V431_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.V440_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v448.V448_CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(DEFAULT_BEDROCK_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.V465_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 
     /**
@@ -77,5 +79,9 @@ public class BedrockVersionUtils {
             }
         }
         return null;
+    }
+
+    public static int getLatestProtocolVersion() {
+        return LATEST_CODEC.getProtocolVersion();
     }
 }

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -35,6 +35,7 @@ import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
 import com.nukkitx.protocol.bedrock.v465.Bedrock_v465;
 import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
 import com.nukkitx.protocol.bedrock.v475.Bedrock_v475;
+import com.nukkitx.protocol.bedrock.v486.Bedrock_v486;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +48,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v475.V475_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v486.V486_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -62,6 +63,7 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v448.V448_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.V465_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.V471_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v475.V475_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -31,6 +31,7 @@ import com.nukkitx.protocol.bedrock.v422.Bedrock_v422;
 import com.nukkitx.protocol.bedrock.v428.Bedrock_v428;
 import com.nukkitx.protocol.bedrock.v431.Bedrock_v431;
 import com.nukkitx.protocol.bedrock.v440.Bedrock_v440;
+import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v440.V440_CODEC;
+    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v448.V448_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -58,6 +59,7 @@ public class BedrockVersionUtils {
                 .build());
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v428.V428_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.V431_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.V440_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(DEFAULT_BEDROCK_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -34,6 +34,7 @@ import com.nukkitx.protocol.bedrock.v440.Bedrock_v440;
 import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
 import com.nukkitx.protocol.bedrock.v465.Bedrock_v465;
 import com.nukkitx.protocol.bedrock.v471.Bedrock_v471;
+import com.nukkitx.protocol.bedrock.v475.Bedrock_v475;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,24 +47,21 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v471.V471_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v475.V475_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
     public static final List<BedrockPacketCodec> SUPPORTED_BEDROCK_CODECS = new ArrayList<>();
 
     static {
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v419.V419_CODEC.toBuilder()
-                .minecraftVersion("1.16.100/1.16.101") // We change this as 1.16.100.60 is a beta
-                .build());
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v422.V422_CODEC.toBuilder()
-                .minecraftVersion("1.16.200/1.16.201")
-                .build());
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v419.V419_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v422.V422_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v428.V428_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.V431_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.V440_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v448.V448_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.V465_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.V471_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -32,6 +32,7 @@ import com.nukkitx.protocol.bedrock.v428.Bedrock_v428;
 import com.nukkitx.protocol.bedrock.v431.Bedrock_v431;
 import com.nukkitx.protocol.bedrock.v440.Bedrock_v440;
 import com.nukkitx.protocol.bedrock.v448.Bedrock_v448;
+import com.nukkitx.protocol.bedrock.v448.Bedrock_v465;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +45,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v448.V448_CODEC;
+    public static final BedrockPacketCodec DEFAULT_BEDROCK_CODEC = Bedrock_v465.V465_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -60,6 +61,7 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v428.V428_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.V431_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.V440_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v448.V448_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(DEFAULT_BEDROCK_CODEC);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/config/ConfigReader.java
+++ b/src/main/java/org/geysermc/globallinkserver/config/ConfigReader.java
@@ -57,7 +57,7 @@ public class ConfigReader {
 
     private static void createConfig() {
         try {
-            Files.copy(ConfigReader.class.getResourceAsStream("config.json"), CONFIG_PATH);
+            Files.copy(ConfigReader.class.getResourceAsStream("/config.json"), CONFIG_PATH);
         } catch (IOException exception) {
             throw new RuntimeException("Failed to copy config", exception);
         }

--- a/src/main/java/org/geysermc/globallinkserver/java/JavaPlayer.java
+++ b/src/main/java/org/geysermc/globallinkserver/java/JavaPlayer.java
@@ -26,8 +26,8 @@
 package org.geysermc.globallinkserver.java;
 
 import com.github.steveice10.mc.auth.data.GameProfile;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerChatPacket;
-import com.github.steveice10.mc.protocol.packet.ingame.server.ServerDisconnectPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundChatPacket;
+import com.github.steveice10.mc.protocol.packet.login.clientbound.ClientboundLoginDisconnectPacket;
 import com.github.steveice10.packetlib.Session;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -45,12 +45,12 @@ public class JavaPlayer implements Player {
 
     @Override
     public void sendMessage(String message) {
-        session.send(new ServerChatPacket(jsonFormatMessage(message)));
+        session.send(new ClientboundChatPacket(jsonFormatMessage(message)));
     }
 
     @Override
     public void disconnect(String reason) {
-        session.send(new ServerDisconnectPacket(jsonFormatMessage(reason)));
+        session.send(new ClientboundLoginDisconnectPacket(jsonFormatMessage(reason)));
         session.disconnect(reason);
     }
 

--- a/src/main/java/org/geysermc/globallinkserver/java/JavaServer.java
+++ b/src/main/java/org/geysermc/globallinkserver/java/JavaServer.java
@@ -35,13 +35,18 @@ import com.github.steveice10.mc.protocol.data.game.command.CommandParser;
 import com.github.steveice10.mc.protocol.data.game.command.CommandType;
 import com.github.steveice10.mc.protocol.data.game.command.properties.IntegerProperties;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
+import com.github.steveice10.mc.protocol.data.game.level.LightUpdateData;
+import com.github.steveice10.mc.protocol.data.game.level.block.BlockEntityInfo;
 import com.github.steveice10.mc.protocol.data.status.PlayerInfo;
 import com.github.steveice10.mc.protocol.data.status.ServerStatusInfo;
 import com.github.steveice10.mc.protocol.data.status.VersionInfo;
 import com.github.steveice10.mc.protocol.data.status.handler.ServerInfoBuilder;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundCommandsPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundLoginPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.player.ClientboundPlayerAbilitiesPacket;
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.player.ClientboundPlayerPositionPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundLevelChunkWithLightPacket;
+import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.Server;
 import com.github.steveice10.packetlib.event.server.ServerAdapter;
 import com.github.steveice10.packetlib.event.server.ServerClosedEvent;
@@ -53,6 +58,9 @@ import net.kyori.adventure.text.Component;
 import org.geysermc.globallinkserver.config.Config;
 import org.geysermc.globallinkserver.link.LinkManager;
 import org.geysermc.globallinkserver.player.PlayerManager;
+
+import java.util.ArrayList;
+import java.util.BitSet;
 
 import static com.github.steveice10.mc.protocol.codec.MinecraftCodec.CODEC;
 
@@ -113,6 +121,8 @@ public class JavaServer implements org.geysermc.globallinkserver.Server {
                             false,
                             false
                     ));
+
+                    session.send(new ClientboundPlayerAbilitiesPacket(false, false, false, false, 0f, 0f));
 
                     // Just send the position without sending chunks
                     // This loads the player into an empty world and stops them from moving

--- a/src/main/java/org/geysermc/globallinkserver/java/PacketHandler.java
+++ b/src/main/java/org/geysermc/globallinkserver/java/PacketHandler.java
@@ -27,12 +27,12 @@ package org.geysermc.globallinkserver.java;
 
 import com.github.steveice10.mc.auth.data.GameProfile;
 import com.github.steveice10.mc.protocol.MinecraftConstants;
-import com.github.steveice10.mc.protocol.packet.ingame.client.ClientChatPacket;
+import com.github.steveice10.mc.protocol.packet.ingame.serverbound.ServerboundChatPacket;
 import com.github.steveice10.packetlib.Session;
 import com.github.steveice10.packetlib.event.session.ConnectedEvent;
 import com.github.steveice10.packetlib.event.session.DisconnectedEvent;
-import com.github.steveice10.packetlib.event.session.PacketReceivedEvent;
 import com.github.steveice10.packetlib.event.session.SessionAdapter;
+import com.github.steveice10.packetlib.packet.Packet;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.globallinkserver.link.LinkManager;
 import org.geysermc.globallinkserver.player.PlayerManager;
@@ -48,10 +48,10 @@ public class PacketHandler extends SessionAdapter {
     private long lastCommand;
 
     @Override
-    public void packetReceived(PacketReceivedEvent event) {
+    public void packetReceived(Session session, Packet packet) {
         try {
-            if (event.getPacket() instanceof ClientChatPacket) {
-                String message = ((ClientChatPacket) event.getPacket()).getMessage();
+            if (packet instanceof ServerboundChatPacket) {
+                String message = ((ServerboundChatPacket) packet).getMessage();
 
                 if (message.startsWith("/")) {
                     long now = System.currentTimeMillis();

--- a/src/main/java/org/geysermc/globallinkserver/java/TagManager.java
+++ b/src/main/java/org/geysermc/globallinkserver/java/TagManager.java
@@ -58,7 +58,7 @@ public class TagManager {
         overworldTag.put(new ByteTag("piglin_safe", (byte) 0));
         overworldTag.put(new ByteTag("natural", (byte) 0));
         overworldTag.put(new FloatTag("ambient_light", 0f));
-        overworldTag.put(new StringTag("infiniburn", "minecraft:infiniburn_end"));
+        overworldTag.put(new StringTag("infiniburn", "#minecraft:infiniburn_end"));
         overworldTag.put(new ByteTag("respawn_anchor_works", (byte) 0));
         overworldTag.put(new ByteTag("has_skylight", (byte) 0));
         overworldTag.put(new ByteTag("bed_works", (byte) 0));


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `f905a8d..6c0cc48`
**Files Changed:** 11 (10 programming files)
**Programming Ratio:** 90.9%

**Commits included:**
- Added support for Bedrock 1.19
- Added support for Bedrock 1.18.30
- Fix Java 1.18.2 support
- Updated to Java 1.18.2
- Update Java protocol dependencies
- Added support for 1.18.10
- Make it work
- Merge remote-tracking branch 'origin/feat/JE-1.18-support'
- Don't move to Java Edition 1.18 yet
- Allow the server to start again
... and 5 more commits